### PR TITLE
Allow different versions

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,7 +37,7 @@ class mongodb (
   $servicename     = $mongodb::params::service,
   $logpath         = '/var/log/mongodb/mongodb.log',
   $logappend       = true,
-  $mongofork       = true,
+  $mongofork       = $mongodb::params::mongofork,
   $port            = '27017',
   $dbpath          = '/var/lib/mongodb',
   $nojournal       = undef,
@@ -68,7 +68,7 @@ class mongodb (
   $profile         = undef,
   $slowms          = undef,
   $version         = installed,
-  $upstart_expect = $mongodb::params::expect,
+  $upstart_expect  = 'none',
 ) inherits mongodb::params {
 
   if $enable_10gen {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,7 @@ class mongodb::params{
       $package = 'mongodb-server'
       $service = 'mongod'
       $pkg_10gen = 'mongo-10gen-server'
+      $mongofork = true
     }
     'debian': {
       $locations = {
@@ -16,11 +17,11 @@ class mongodb::params{
         'Debian': { $init = 'sysv' }
         'Ubuntu': { $init = 'upstart' }
       }
-      $expect = 'daemon'
       $source  = 'mongodb::sources::apt'
       $package = 'mongodb'
       $service = 'mongodb'
       $pkg_10gen = 'mongodb-10gen'
+      $mongofork = false
     }
     default: {
       fail ("mongodb: ${::operatingsystem} is not supported.")

--- a/spec/classes/mongodb_spec.rb
+++ b/spec/classes/mongodb_spec.rb
@@ -34,6 +34,7 @@ describe 'mongodb', :type => :class do
 
       it {
         should contain_file('/etc/init/mongodb.conf')
+        should_not contain_file('/etc/init/mongodb.conf')
           .with_content(/expect daemon/)
       }
     end
@@ -108,12 +109,23 @@ describe 'mongodb', :type => :class do
 
     describe 'with no upstart expect' do
       let :params do
-        { :upstart_expect => '' }
+        { :upstart_expect => 'none' }
       end
 
       it {
         should_not contain_file('/etc/init/mongodb.conf')
           .with_content(/expect/)
+      }
+    end
+
+    describe 'with daemon upstart expect' do
+      let :params do
+        { :upstart_expect => 'daemon' }
+      end
+
+      it {
+        should contain_file('/etc/init/mongodb.conf')
+          .with_content(/expect daemon/)
       }
     end
 

--- a/templates/mongod.upstart.conf.erb
+++ b/templates/mongod.upstart.conf.erb
@@ -9,7 +9,7 @@ pre-start script
     mkdir -p /var/log/mongodb/
 end script
 
-<% if @upstart_expect != '' -%>
+<% if @upstart_expect != 'none' -%>
 expect <%= @upstart_expect %>
 <% end -%>
 


### PR DESCRIPTION
Allows you to install an arbritary version of mongodb.

Changes the forking model of mongodb on debian to false as this was causing issues with older versions of mongo.

Added a parameter to set the expect stanza in the upstart script. Setting param to 'none' means the stanza is not included.
